### PR TITLE
Target Android 12 (API 32).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -6,8 +6,10 @@
         <c:change date="2022-08-13T00:00:00+00:00" summary="Replaced nypl http module with palace fork."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-08-13T06:28:23+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.7">
-      <c:changes/>
+    <c:release date="2022-10-20T05:46:45+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.2.7">
+      <c:changes>
+        <c:change date="2022-10-20T05:46:45+00:00" summary="Changed target version to Android 12."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-  if ("$gradle.gradleVersion" != "7.2") {
-    throw new GradleException("Gradle version 7.2 is required (received $gradle.gradleVersion)")
+  if ("$gradle.gradleVersion" != "7.4") {
+    throw new GradleException("Gradle version 7.4 is required (received $gradle.gradleVersion)")
   }
 
   // https://github.com/gradle/gradle/issues/11308#issuecomment-554317655
@@ -20,7 +20,7 @@ buildscript {
     classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
     classpath "digital.wup:android-maven-publish:3.6.3"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath "com.android.tools.build:gradle:7.0.2"
+    classpath "com.android.tools.build:gradle:7.3.1"
     classpath "de.undercouch:gradle-download-task:4.1.2"
     classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.0.0"
   }
@@ -35,10 +35,10 @@ plugins {
 }
 
 ext {
-  androidBuildToolsVersion = "30.0.2"
-  androidCompileSDKVersion = 31
+  androidBuildToolsVersion = "32.0.0"
+  androidCompileSDKVersion = 32
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 28
+  androidTargetSDKVersion = 32
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 12 (API 32), including necessary dependency and gradle upgrades.

**Why are we doing this? (w/ JIRA link if applicable)**

Apps will be required to target Android 12 in November. Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

Adobe DRMed books should open successfully, and the controls and table of contents should all work.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested some Adobe books.